### PR TITLE
Update database image to MariaDB in installation guide

### DIFF
--- a/docs/how-to/installation/compose.adoc
+++ b/docs/how-to/installation/compose.adoc
@@ -40,8 +40,7 @@ services:
         - "pledger_uploads:/opt/storage/upload"
     pledger_db:
       container_name: pledger_db
-      image: mysql
-      args: ["--default-authentication-plugin=mysql_native_password"]
+      image: mariadb:11.2
       volumes:
         - "pledger_db:/var/lib/mysql"
       environment:


### PR DESCRIPTION
Switched the database image from MySQL to MariaDB:11.2 in the Docker Compose example. This ensures compatibility with the latest configurations and aligns with best practices for database setup. Adjusted the example for clarity and accuracy.

Relates to: https://github.com/pledger-io/build-tooling/issues/4