### PR TITLE
Set up Cursor Cloud dev environment for the docs site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **Pledger.io user documentation** site — a Hugo Extended static site using the Hinode theme. It does **not** contain the Pledger.io application source (that lives in separate `pledger-io/*` repos). Development here means building and previewing the docs site.
+
+### Toolchain (already installed in the VM snapshot)
+- Hugo Extended `0.163.1` (must be the *extended* build; SCSS won't compile otherwise), Go (for Hugo modules), PowerShell `pwsh` (build scripts are `.ps1`), Node.js 22 (OpenAPI bundling), and `lychee` (link checker).
+- The startup update script runs `hugo mod get` to refresh the Hinode theme module.
+
+### Build/run (see `README.md` for the canonical commands)
+- Generated files are **not committed** (they're gitignored): `content/releases/*.md`, `data/releases*.yaml`, `static/openapi/openapi.bundle.yaml`. You must regenerate them before a build or the site will be missing the Releases and API-docs pages:
+  - `pwsh scripts/generate-releases.ps1` — regenerates the Releases pages from `scripts/releases-source.md`.
+  - `pwsh scripts/bundle-openapi.ps1` — bundles `static/openapi/openapi.yml` into `openapi.bundle.yaml` via `npx --yes @redocly/cli`. This needs network access for `npx`; the Redocly bundler prints non-fatal duplicate-schema WARNINGs that can be ignored.
+- Dev server: `hugo server -D` (serves on `http://localhost:1313/`). Use `--bind 0.0.0.0` if you need to reach it from outside the VM.
+- Production build: `hugo --gc --minify` (outputs to `public/`). Deprecation WARNINGs are pre-existing and non-fatal.
+
+### Lint (link checking)
+- The CI "lint" is a lychee link check over the built `public/` dir. Reproduce locally:
+  - `hugo --gc --minify` then `pwsh scripts/prepare-lychee-config.ps1` then `lychee --config .lychee.ci.toml --root-dir "$(pwd)/public" ./public`.
+- There is no separate unit-test suite; a clean `hugo` build + a 0-error lychee run is the effective test.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Pledger.io **user documentation** site (Hugo Extended + Hinode theme) and documents it for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering toolchain, generated-file caveats, build/run, and the lychee link-check "lint".
- Update script configured to `hugo mod get` (refreshes the Hinode theme module on startup).

No application code was changed; only environment setup + docs.

## Environment installed
- Hugo Extended `0.163.1`, PowerShell `7.4.6` (`pwsh`), `lychee` `0.24.2`. Go `1.26.4` and Node `22` were already present.

## Verification

| Step | Command | Result |
|------|---------|--------|
| Modules | `hugo mod get` | OK |
| Generate releases | `pwsh scripts/generate-releases.ps1` | 54 releases generated |
| Bundle OpenAPI | `pwsh scripts/bundle-openapi.ps1` | bundle produced |
| Build | `hugo --gc --minify` | 79 pages built |
| Lint (links) | `lychee --config .lychee.ci.toml --root-dir public ./public` | 3127 OK, 0 errors |
| Run | `hugo server -D` | serves on `:1313`, homepage/releases/api-docs return 200 |

### Hello-world walkthrough
Browsed the running site: homepage → Getting Started → site search for "budget" (returned results) → opened a budget doc page → Releases timeline.

[hugo_docs_site_walkthrough.mp4](https://cursor.com/agents/bc-f8886f8e-e4b4-425e-adf6-c04906b57124/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhugo_docs_site_walkthrough.mp4)

[Search returns results for budget](https://cursor.com/agents/bc-f8886f8e-e4b4-425e-adf6-c04906b57124/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_budget_results.webp)
[Releases timeline](https://cursor.com/agents/bc-f8886f8e-e4b4-425e-adf6-c04906b57124/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freleases_timeline.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8886f8e-e4b4-425e-adf6-c04906b57124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8886f8e-e4b4-425e-adf6-c04906b57124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

