### PR TITLE
Unify docs section names across nav and landing pages.

### DIFF
--- a/DOCUMENTATION-AUDIT.md
+++ b/DOCUMENTATION-AUDIT.md
@@ -48,10 +48,10 @@ Tutorial pages reference PNGs that are **not** in the repo. Only logos + 3 SVG t
 
 ### Home page & messaging
 
-- [ ] Change home hero CTA from `/architecture/` to `/getting-started/` (or `/getting-started/installation/docker/`)
-- [ ] Rewrite home hero copy: align with personal finance positioning (not “teams” / “operational finance”)
-- [ ] Fix home page link: Docker install is under Getting Started, not How-To (`content/_index.md` line ~43)
-- [ ] Unify terminology: home uses “Reference guide” / “Explanations” but nav uses “Architecture” / “Financial concepts”
+- [x] Change home hero CTA from `/architecture/` to `/getting-started/` (or `/getting-started/installation/docker/`)
+- [x] Rewrite home hero copy: align with personal finance positioning (not “teams” / “operational finance”)
+- [x] Fix home page link: Docker install is under Getting Started, not How-To (`content/_index.md` line ~43)
+- [x] Unify terminology: home uses “Reference guide” / “Explanations” but nav uses “Architecture” / “Financial concepts”
 
 ### Brand assets
 

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -4,12 +4,12 @@
   weight = 10
 
 [[main]]
-  name = "How to guides"
+  name = "How-to guides"
   pageRef = "/how-to/"
   weight = 20
 
 [[main]]
-  name = "Financial concepts"
+  name = "Concepts"
   pageRef = "/concepts/"
   weight = 30
 

--- a/content/architecture/_index.md
+++ b/content/architecture/_index.md
@@ -1,12 +1,12 @@
 ---
-title: Technical documentation
+title: Architecture
 description: Technical documentation of Pledger.io
 type: docs
 weight: 3
 content_blocks:
   - _bookshop_name: hero
     heading:
-      title: Architecture & Technical Documentation
+      title: Architecture
       content: Explore how Pledger.io is designed, how core processes work, and how the API is structured.
     background:
       color: primary

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started
+title: Getting Started
 type: docs
 weight: 1
 description: Tutorial guides to get productive with Pledger.io quickly.

--- a/content/how-to/_index.md
+++ b/content/how-to/_index.md
@@ -1,12 +1,12 @@
 ---
-title: How-To Guides
+title: How-to guides
 description: Task-focused guides for managing and operating Pledger.io.
 type: docs
 weight: 2
 content_blocks:
   - _bookshop_name: hero
     heading:
-      title: How-To Guides
+      title: How-to guides
       content: Step-by-step instructions to help you complete common tasks in Pledger.io.
     background:
       color: primary


### PR DESCRIPTION
Align Getting Started, How-to guides, Concepts, and Architecture labels so home cards and top nav match (issue #38).